### PR TITLE
Bump version to 2.0.2-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2022-02-28
+
 ### Changed
 
 - Updated end-to-end tests, by [@compulim](https://github.com/compulim), in PR [#23](https://github.com/compulim/p-defer-es5/pull/23)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "p-defer-es5",
-  "version": "2.0.1-0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "p-defer-es5",
-  "version": "2.0.1",
+  "version": "2.0.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p-defer-es5",
-  "version": "2.0.1-0",
+  "version": "2.0.1",
   "description": "",
   "engines": {
     "node": ">= 12.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "p-defer-es5",
-  "version": "2.0.1",
+  "version": "2.0.2-0",
   "description": "",
   "engines": {
     "node": ">= 12.2.0"


### PR DESCRIPTION
## Summary

Bump version to `2.0.2-0` after releasing `2.0.1`.

## Changelog

(No changelog for bump version.)

## Design considerations

Steps to release and bump versions:

```sh
git fetch --all
git checkout origin/main
git clean -fdx
git checkout -b bump-2.0.2-0
vi CHANGELOG.md # mark changes to release in 2.0.1
npm version patch
git push -u origin v2.0.1 # release 2.0.1 to npm
npm version prepatch --no-git-tag-version
git commit -a -m "2.0.2-0"
git push -u origin bump-2.0.2-0
```

## Specific changes

- Release `2.0.1`
- Add date to `CHANGELOG.md`
- Run `npm version prepatch`

## Reminders

<!-- Checks all boxes even if it is irrelevant to this pull request. -->

- [x] I have updated `CHANGELOG.md`
- [x] I have added tests for new code
- [x] I have updated documentations
